### PR TITLE
Modify the regex statement to work on MacGPG

### DIFF
--- a/src/fluidkeys.go
+++ b/src/fluidkeys.go
@@ -15,7 +15,7 @@ func main() {
 	}
 	outString := string(out)
 
-	re := regexp.MustCompile(`gpg \(GnuPG\) ([0-9.]+)`)
+	re := regexp.MustCompile(`gpg \(GnuPG.*\) (\d+\.\d+\.\d+)`)
 
 	match := re.FindStringSubmatch(outString)
 	if match != nil {


### PR DESCRIPTION
When running `gpg --version` on a mac, it outputs:

```
gpg (GnuPG/MacGPG2) 2.2.8
libgcrypt 1.8.3
Copyright (C) 2018 Free Software Foundation, Inc.
```

This didn't fit the regex we were using.